### PR TITLE
add python3-psycopg2 package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 FROM quay.io/fedora/fedora:36
 
 RUN dnf -y update && \
-    dnf -y install python3-pip git pcp telnet nmap bind-utils net-tools curl traceroute mtr tcpdump community-mysql postgresql rsync skopeo redis && \
+    dnf -y install python3-pip python3-psycopg2 git pcp telnet nmap bind-utils net-tools curl traceroute mtr tcpdump community-mysql postgresql rsync skopeo redis && \
     dnf clean all
 
 RUN pip install awscli redis


### PR DESCRIPTION
This adds the psycopg2 python3 package which is useful when connecting to Postgres from python scripts