### PR TITLE
add-openssl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 FROM quay.io/fedora/fedora:39
 
 RUN dnf -y update && \
-    dnf -y install python3-pip python3-PyMySQL python3-psycopg2 git pcp telnet nmap bind-utils net-tools curl traceroute mtr tcpdump community-mysql postgresql rsync skopeo redis tmux iputils && \
+    dnf -y install python3-pip python3-PyMySQL python3-psycopg2 git pcp telnet nmap bind-utils net-tools curl traceroute mtr tcpdump community-mysql postgresql rsync skopeo redis tmux iputils openssl && \
     dnf clean all
 
 RUN pip install awscli redis


### PR DESCRIPTION
Adds openssl client.

Will hopefully be useful for debugging TLS issues with the `openssl s_client` subcommand.

FIPS is a work of art.